### PR TITLE
feat: tombi.schemas + tombi.tomlVersion editor settings (closes #113, refs #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Add to your `coc-settings.json` (`:CocConfig`):
   "tombi.enabled": true,
   "tombi.path": null,
   "tombi.args": [],
-  "tombi.env": {}
+  "tombi.env": {},
+  "tombi.schemas": []
 }
 ```
 
@@ -87,8 +88,25 @@ Add to your `coc-settings.json` (`:CocConfig`):
 | `tombi.path` | Absolute path to the tombi executable. If not set, searches PATH. | `null` |
 | `tombi.args` | Additional arguments passed to `tombi lsp` | `[]` |
 | `tombi.env` | Environment variables passed to the tombi process | `{}` |
+| `tombi.schemas` | Editor-level JSON schema associations registered on startup. Each entry calls `tombi/associateSchema`. | `[]` |
 
-Formatter, linter, and schema settings are configured in project-level `tombi.toml` files, not in `coc-settings.json`.
+Formatter, linter, and project-wide schema settings are configured in project-level `tombi.toml` files. For editor-level schema overrides (similar to `yaml.schemas` in coc-yaml), use `tombi.schemas`:
+
+```json
+{
+  "tombi.schemas": [
+    {
+      "uri": "https://json.schemastore.org/cargo.json",
+      "fileMatch": ["Cargo.toml"],
+      "tomlVersion": "v1.1.0"
+    },
+    {
+      "uri": "https://json.schemastore.org/pyproject.json",
+      "fileMatch": ["pyproject.toml"]
+    }
+  ]
+}
+```
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Add to your `coc-settings.json` (`:CocConfig`):
   "tombi.path": null,
   "tombi.args": [],
   "tombi.env": {},
+  "tombi.tomlVersion": "v1.1.0",
   "tombi.schemas": []
 }
 ```
@@ -88,6 +89,7 @@ Add to your `coc-settings.json` (`:CocConfig`):
 | `tombi.path` | Absolute path to the tombi executable. If not set, searches PATH. | `null` |
 | `tombi.args` | Additional arguments passed to `tombi lsp` | `[]` |
 | `tombi.env` | Environment variables passed to the tombi process | `{}` |
+| `tombi.tomlVersion` | Default TOML version (`"v1.0.0"` or `"v1.1.0"`). Sent to Tombi via `workspace/didChangeConfiguration` and used as fallback for `tombi.schemas` entries that omit `tomlVersion`. Schema/comment directives still take precedence. | `"v1.1.0"` |
 | `tombi.schemas` | Editor-level JSON schema associations registered on startup. Each entry calls `tombi/associateSchema`. | `[]` |
 
 Formatter, linter, and project-wide schema settings are configured in project-level `tombi.toml` files. For editor-level schema overrides (similar to `yaml.schemas` in coc-yaml), use `tombi.schemas`:

--- a/package.json
+++ b/package.json
@@ -133,6 +133,43 @@
           "description": "Prompt before downloading updates. If false, downloads automatically.",
           "type": "boolean",
           "default": true
+        },
+        "tombi.schemas": {
+          "description": "Associate JSON schemas with TOML files. Each entry is registered with the language server on startup via tombi/associateSchema. For project-wide config, prefer tombi.toml in the workspace root.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "object",
+            "required": [
+              "uri",
+              "fileMatch"
+            ],
+            "properties": {
+              "uri": {
+                "type": "string",
+                "description": "Schema URI (http(s):// or file://)."
+              },
+              "fileMatch": {
+                "type": "array",
+                "description": "Glob patterns the schema applies to (e.g. [\"Cargo.toml\"], [\"pyproject.toml\"]).",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "title": {
+                "type": "string",
+                "description": "Optional display title for the schema."
+              },
+              "description": {
+                "type": "string",
+                "description": "Optional description shown alongside the schema."
+              },
+              "tomlVersion": {
+                "type": "string",
+                "description": "TOML version to use with this schema (e.g. \"v1.0.0\" or \"v1.1.0\")."
+              }
+            }
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -134,6 +134,15 @@
           "type": "boolean",
           "default": true
         },
+        "tombi.tomlVersion": {
+          "description": "Default TOML specification version used by the language server when neither a schema directive, comment directive, nor tombi.toml specifies one. Sent to Tombi via workspace/didChangeConfiguration as `toml-version`.",
+          "type": "string",
+          "enum": [
+            "v1.0.0",
+            "v1.1.0"
+          ],
+          "default": "v1.1.0"
+        },
         "tombi.schemas": {
           "description": "Associate JSON schemas with TOML files. Each entry is registered with the language server on startup via tombi/associateSchema. For project-wide config, prefer tombi.toml in the workspace root.",
           "type": "array",

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,10 @@ export class Config {
   get schemas(): SchemaEntry[] {
     return this.cfg.get<SchemaEntry[]>('schemas', []);
   }
+
+  get tomlVersion(): string {
+    return this.cfg.get<string>('tomlVersion', 'v1.1.0');
+  }
 }
 
 export default new Config();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,13 @@
 import { workspace, WorkspaceConfiguration } from 'coc.nvim';
 
+export interface SchemaEntry {
+  uri: string;
+  fileMatch: string[];
+  title?: string;
+  description?: string;
+  tomlVersion?: string;
+}
+
 export class Config {
   private readonly rootSection = 'tombi';
   private cfg: WorkspaceConfiguration;
@@ -27,6 +35,10 @@ export class Config {
 
   get env(): Record<string, string> {
     return this.cfg.get<Record<string, string>>('env', {});
+  }
+
+  get schemas(): SchemaEntry[] {
+    return this.cfg.get<SchemaEntry[]>('schemas', []);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { refreshCache } from './commands/cache';
 import { showVersion } from './commands/version';
 import { selectSchema } from './commands/selectSchema';
 import { registerUserSchemas } from './userSchemas';
+import { syncConfigToServer } from './syncConfig';
 
 export async function activate(context: ExtensionContext): Promise<void> {
   if (!config.enabled) {
@@ -39,6 +40,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
       window.showInformationMessage('Tombi Language Server restarted.');
     }),
   );
+
+  // Push tombi.tomlVersion to the server and keep it in sync (non-blocking)
+  syncConfigToServer(client)
+    .then((disposable) => context.subscriptions.push(disposable))
+    .catch((e) => {
+      window.showWarningMessage(`tombi config sync failed: ${e}`);
+    });
 
   // Register user-defined schemas from tombi.schemas (non-blocking)
   registerUserSchemas(client, config.schemas).catch((e) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { registerCommand } from './commands';
 import { refreshCache } from './commands/cache';
 import { showVersion } from './commands/version';
 import { selectSchema } from './commands/selectSchema';
+import { registerUserSchemas } from './userSchemas';
 
 export async function activate(context: ExtensionContext): Promise<void> {
   if (!config.enabled) {
@@ -38,6 +39,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
       window.showInformationMessage('Tombi Language Server restarted.');
     }),
   );
+
+  // Register user-defined schemas from tombi.schemas (non-blocking)
+  registerUserSchemas(client, config.schemas).catch((e) => {
+    window.showWarningMessage(`tombi.schemas registration failed: ${e}`);
+  });
 
   // Background update check (non-blocking)
   if (tombiBin.source === 'stored') {

--- a/src/syncConfig.ts
+++ b/src/syncConfig.ts
@@ -1,0 +1,35 @@
+import { LanguageClient, workspace, Disposable } from 'coc.nvim';
+import config from './config';
+
+const DID_CHANGE_CONFIGURATION = 'workspace/didChangeConfiguration';
+
+function buildTombiSettings(): Record<string, unknown> {
+  return {
+    tombi: {
+      'toml-version': config.tomlVersion,
+    },
+  };
+}
+
+async function pushSettings(client: LanguageClient): Promise<void> {
+  try {
+    await client.sendNotification(DID_CHANGE_CONFIGURATION, {
+      settings: buildTombiSettings(),
+    });
+  } catch (e) {
+    console.error('tombi config sync failed:', e);
+  }
+}
+
+export async function syncConfigToServer(
+  client: LanguageClient,
+): Promise<Disposable> {
+  await client.onReady();
+  await pushSettings(client);
+
+  return workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration('tombi.tomlVersion')) {
+      pushSettings(client);
+    }
+  });
+}

--- a/src/userSchemas.ts
+++ b/src/userSchemas.ts
@@ -1,0 +1,36 @@
+import { LanguageClient, window } from 'coc.nvim';
+import { SchemaEntry } from './config';
+import { Methods } from './requestExt';
+
+export async function registerUserSchemas(
+  client: LanguageClient,
+  schemas: SchemaEntry[],
+): Promise<void> {
+  if (schemas.length === 0) return;
+
+  await client.onReady();
+
+  for (const schema of schemas) {
+    if (!schema.uri || !Array.isArray(schema.fileMatch)) {
+      window.showWarningMessage(
+        `Skipping invalid tombi.schemas entry: ${JSON.stringify(schema)}`,
+      );
+      continue;
+    }
+
+    try {
+      await client.sendNotification(Methods.AssociateSchema.METHOD, {
+        uri: schema.uri,
+        fileMatch: schema.fileMatch,
+        title: schema.title,
+        description: schema.description,
+        tomlVersion: schema.tomlVersion,
+        force: true,
+      } as Methods.AssociateSchema.Params);
+    } catch (e) {
+      window.showWarningMessage(
+        `Failed to associate schema ${schema.uri}: ${e}`,
+      );
+    }
+  }
+}

--- a/src/userSchemas.ts
+++ b/src/userSchemas.ts
@@ -1,5 +1,5 @@
 import { LanguageClient, window } from 'coc.nvim';
-import { SchemaEntry } from './config';
+import config, { SchemaEntry } from './config';
 import { Methods } from './requestExt';
 
 export async function registerUserSchemas(
@@ -9,6 +9,8 @@ export async function registerUserSchemas(
   if (schemas.length === 0) return;
 
   await client.onReady();
+
+  const fallbackVersion = config.tomlVersion;
 
   for (const schema of schemas) {
     if (!schema.uri || !Array.isArray(schema.fileMatch)) {
@@ -24,7 +26,7 @@ export async function registerUserSchemas(
         fileMatch: schema.fileMatch,
         title: schema.title,
         description: schema.description,
-        tomlVersion: schema.tomlVersion,
+        tomlVersion: schema.tomlVersion ?? fallbackVersion,
         force: true,
       } as Methods.AssociateSchema.Params);
     } catch (e) {


### PR DESCRIPTION
## Summary

Two related additions to coc-settings.json that expose editor-level Tombi configuration without requiring a `tombi.toml`:

1. **`tombi.schemas`** — array of `{uri, fileMatch, tomlVersion?, title?, description?}` entries, registered on startup via `tombi/associateSchema`. Mirrors `coc-yaml`'s `yaml.schemas` pattern.
2. **`tombi.tomlVersion`** — `"v1.0.0" | "v1.1.0"` (default `"v1.1.0"`). Pushed to Tombi via `workspace/didChangeConfiguration` so the LSP picks it up, and used as the fallback `tomlVersion` for `tombi.schemas` entries that omit it.

## Why default v1.1.0

Tombi's own default is `v1.0.0`, but TOML 1.1 is current (Cargo enables it in Rust 1.94, etc.). Users opting into modern TOML tooling generally expect 1.1 support out of the box; those needing strict 1.0 compatibility can flip the setting.

## LSP integration

Verified against [`tombi-lsp` source](https://github.com/tombi-toml/tombi/tree/main/crates/tombi-lsp/src/handler):

- `handle_initialize` ignores `initializationOptions` (uses `..` destructure), so we cannot pass version that way.
- `did_change_configuration.rs` deserializes `settings.tombi` into `tombi_config::Config`, expecting kebab-case (`"toml-version": "v1.1.0"`).
- TOML version resolution order in Tombi: comment directive → schema → `tombi.toml` → editor (workspace/didChangeConfiguration) → default. So schema/comment overrides still win, but the editor setting trumps Tombi's default.

We send the kebab-case payload manually and re-send on `workspace.onDidChangeConfiguration` when `tombi.tomlVersion` changes — so users can swap versions without restarting the language server.

## Files

- `package.json` — new `tombi.schemas` (array) and `tombi.tomlVersion` (enum) properties
- `src/config.ts` — `schemas` and `tomlVersion` getters, `SchemaEntry` interface
- `src/userSchemas.ts` — startup registration via `tombi/associateSchema` with `tomlVersion` fallback
- `src/syncConfig.ts` — pushes `{tombi: {"toml-version": ...}}` via `workspace/didChangeConfiguration`, re-pushes on config change
- `src/index.ts` — wires both helpers into `activate()` (non-blocking)
- `README.md` — documents both new options with examples

## Test plan

This repo has no test suite. Manual verification:

- [ ] Build clean: `pnpm build` and `npx tsc --noEmit -p .` (verified locally — green)
- [ ] Default behavior: open a TOML 1.1 file (e.g. dotted-key inline arrays), no diagnostic
- [ ] Set `"tombi.tomlVersion": "v1.0.0"`, restart/re-trigger: 1.1 syntax now flagged
- [ ] Live switch: change `tombi.tomlVersion` while LSP running, observe diagnostics update without restart
- [ ] Add a `tombi.schemas` entry without `tomlVersion`, confirm the global fallback applies

Closes #113
Refs #117