### PR TITLE
ci: add docker-based smoke tests for tombi version switching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Build artifacts and dependencies are reinstalled/rebuilt inside the image.
+node_modules
+lib
+
+# Local Git metadata is not needed for the build.
+.git
+.github
+
+# Editor / IDE state.
+.vscode
+.idea
+.claude
+
+# OS junk.
+.DS_Store
+Thumbs.db
+
+# Local-only example artifacts.
+examples/autoload/plug.vim
+examples/local_coc.vim

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,36 @@
+name: coc-toml docker smoke test
+
+# Only runs on the main branch — Docker smoke tests are slower than the
+# regular CI and not gated on PRs.
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          tags: coc-toml-test:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Activation smoke test
+        run: docker run --rm coc-toml-test:ci
+
+      - name: Scenario tests (no-config + with-config v1.0 / v1.1)
+        run: docker run --rm coc-toml-test:ci all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,99 @@
+# Smoke-test image for coc-toml.
+#
+# Builds the extension from local sources, installs Neovim + coc.nvim, and
+# pre-installs the Tombi CLI so fixture-driven scenarios can verify
+# project-level config (tombi.toml) behavior without a live LSP session.
+#
+# Build:
+#   docker build -t coc-toml-test .
+#   # or: podman build -t coc-toml-test .
+#
+# Default smoke test (build artifact + tombi binary):
+#   docker run --rm coc-toml-test
+#
+# All scenarios (no-config + with-config v1.0 / v1.1):
+#   docker run --rm coc-toml-test all
+#
+# Individual scenarios:
+#   docker run --rm coc-toml-test no-config
+#   docker run --rm coc-toml-test with-config-v1.0
+#   docker run --rm coc-toml-test with-config-v1.1
+#
+# Interactive shell (manual poke):
+#   docker run --rm -it --entrypoint bash coc-toml-test
+#
+# Open the sample TOML in nvim:
+#   docker run --rm -it coc-toml-test nvim /work/examples/test.toml
+
+FROM node:24-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    NO_COLOR=1 \
+    PNPM_HOME=/root/.local/share/pnpm \
+    PATH=/root/.local/share/pnpm:$PATH
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+      xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+# Debian bookworm ships neovim 0.7.2; current coc.nvim requires >= 0.8.
+# Pull a recent stable release from upstream instead.
+ARG NVIM_VERSION=v0.10.4
+RUN ARCH=$(uname -m) \
+ && curl -fsSL "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim-linux-${ARCH}.tar.gz" \
+      -o /tmp/nvim.tar.gz \
+ && tar -xzf /tmp/nvim.tar.gz -C /opt \
+ && ln -s "/opt/nvim-linux-${ARCH}/bin/nvim" /usr/local/bin/nvim \
+ && rm /tmp/nvim.tar.gz \
+ && nvim --version | head -1
+
+# Pre-install tombi on PATH so the extension's bootstrap takes the
+# "found in PATH" branch and skips the interactive auto-download prompt
+# (which would hang in headless mode).
+ARG TOMBI_VERSION=0.11.4
+RUN ARCH=$(uname -m) \
+ && TOMBI_TARGET="${ARCH}-unknown-linux-musl" \
+ && curl -fsSL "https://github.com/tombi-toml/tombi/releases/download/v${TOMBI_VERSION}/tombi-cli-${TOMBI_VERSION}-${TOMBI_TARGET}.tar.gz" \
+      -o /tmp/tombi.tar.gz \
+ && tar -xzf /tmp/tombi.tar.gz -C /tmp \
+ && install -m 0755 "/tmp/tombi-cli-${TOMBI_VERSION}-${TOMBI_TARGET}/tombi" /usr/local/bin/tombi \
+ && rm -rf /tmp/tombi.tar.gz "/tmp/tombi-cli-${TOMBI_VERSION}-${TOMBI_TARGET}" \
+ && tombi --version
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+WORKDIR /work
+
+# Install dependencies first so the layer is cached when only source changes.
+# --ignore-scripts skips the `prepare` lifecycle (which would try to build
+# before sources are copied).
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+# Build the extension.
+COPY . .
+RUN pnpm build
+
+# coc.nvim (release branch ships prebuilt JS, no node build needed).
+RUN git clone --depth 1 -b release https://github.com/neoclide/coc.nvim \
+      /root/.local/share/nvim/site/pack/coc/start/coc.nvim
+
+# Drop the built extension into coc's extension directory and declare it
+# in the extensions manifest so coc loads it on startup.
+RUN mkdir -p /root/.config/coc/extensions/node_modules \
+ && ln -s /work /root/.config/coc/extensions/node_modules/coc-toml \
+ && printf '{\n  "dependencies": {\n    "coc-toml": "file:./node_modules/coc-toml"\n  }\n}\n' \
+      > /root/.config/coc/extensions/package.json
+
+# Minimal init.vim and coc-settings.json for the test environment.
+COPY docker/init.vim /root/.config/nvim/init.vim
+COPY docker/coc-settings.json /root/.config/nvim/coc-settings.json
+COPY docker/smoke-test.sh /usr/local/bin/smoke-test
+
+RUN chmod +x /usr/local/bin/smoke-test
+
+ENTRYPOINT ["smoke-test"]

--- a/docker/coc-settings.json
+++ b/docker/coc-settings.json
@@ -1,0 +1,4 @@
+{
+  "tombi.enabled": true,
+  "tombi.tomlVersion": "v1.1.0"
+}

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,58 @@
+# Compose file for running coc-toml smoke tests and ad-hoc sessions.
+#
+# Works with both `docker compose` and `podman compose`.
+#
+#   docker compose -f docker/compose.yaml run --rm test
+#   docker compose -f docker/compose.yaml run --rm test-all
+#   docker compose -f docker/compose.yaml run --rm test-no-config
+#   docker compose -f docker/compose.yaml run --rm test-config-v1.0
+#   docker compose -f docker/compose.yaml run --rm test-config-v1.1
+#   docker compose -f docker/compose.yaml run --rm shell
+#   docker compose -f docker/compose.yaml run --rm nvim
+#
+# All services share the same image built from the repository Dockerfile.
+
+x-base: &base
+  build:
+    context: ..
+    dockerfile: Dockerfile
+  image: coc-toml-test:latest
+
+services:
+  # Activation-only smoke test (tombi LSP reaches running state).
+  test:
+    <<: *base
+    command: []
+
+  # Run every scenario in sequence inside a single container.
+  test-all:
+    <<: *base
+    command: ["all"]
+
+  # No tombi.toml in the working directory; falls back to editor default v1.1.0.
+  test-no-config:
+    <<: *base
+    command: ["no-config"]
+
+  # Project tombi.toml pins toml-version to v1.0.0 (overrides editor default).
+  test-config-v1.0:
+    <<: *base
+    command: ["with-config-v1.0"]
+
+  # Project tombi.toml explicitly pins toml-version to v1.1.0.
+  test-config-v1.1:
+    <<: *base
+    command: ["with-config-v1.1"]
+
+  shell:
+    <<: *base
+    entrypoint: ["bash"]
+    tty: true
+    stdin_open: true
+
+  nvim:
+    <<: *base
+    entrypoint: ["nvim"]
+    command: ["/work/examples/test.toml"]
+    tty: true
+    stdin_open: true

--- a/docker/fixtures/no-config/sample.toml
+++ b/docker/fixtures/no-config/sample.toml
@@ -1,0 +1,14 @@
+# Fixture: no tombi.toml here.
+#
+# Content is intentionally TOML 1.0-compatible so the file lints cleanly
+# under tombi's default (v1.0.0) without any project configuration. This
+# proves the toolchain works end-to-end before we exercise version
+# switching in the with-config-* fixtures.
+
+[package]
+name = "no-config-sample"
+version = "0.1.0"
+
+[settings]
+enabled = true
+verbose = false

--- a/docker/fixtures/with-config-v1.0/sample.toml
+++ b/docker/fixtures/with-config-v1.0/sample.toml
@@ -1,0 +1,13 @@
+# Fixture: sibling tombi.toml pins toml-version to v1.0.0.
+#
+# Multi-line inline tables are TOML 1.1-only, so `tombi lint` MUST fail here
+# even though the same content lints clean in the v1.1 fixtures.
+
+[package]
+name = "pinned-v1-0-sample"
+version = "0.1.0"
+
+config = {
+  enabled = true,
+  verbose = false,
+}

--- a/docker/fixtures/with-config-v1.0/tombi.toml
+++ b/docker/fixtures/with-config-v1.0/tombi.toml
@@ -1,0 +1,3 @@
+# Project-level tombi config: pin TOML to v1.0.0.
+# This should override the editor-level tombi.tomlVersion setting.
+toml-version = "v1.0.0"

--- a/docker/fixtures/with-config-v1.1/sample.toml
+++ b/docker/fixtures/with-config-v1.1/sample.toml
@@ -1,0 +1,12 @@
+# Fixture: sibling tombi.toml explicitly pins toml-version to v1.1.0.
+#
+# Multi-line inline tables are TOML 1.1-only; this file must lint successfully.
+
+[package]
+name = "pinned-v1-1-sample"
+version = "0.1.0"
+
+config = {
+  enabled = true,
+  verbose = false,
+}

--- a/docker/fixtures/with-config-v1.1/tombi.toml
+++ b/docker/fixtures/with-config-v1.1/tombi.toml
@@ -1,0 +1,3 @@
+# Project-level tombi config: explicitly pin TOML to v1.1.0.
+# Verifies the override path even when the editor default would already be v1.1.0.
+toml-version = "v1.1.0"

--- a/docker/init.vim
+++ b/docker/init.vim
@@ -1,0 +1,20 @@
+" Minimal init.vim for coc-toml smoke testing.
+"
+" coc.nvim is loaded via Vim's native package path
+" (~/.local/share/nvim/site/pack/coc/start/coc.nvim) so no plugin manager
+" is required.
+
+set nocompatible
+filetype plugin indent on
+syntax on
+
+set hidden
+set updatetime=300
+set shortmess+=c
+set signcolumn=yes
+
+" Tell coc where to find its settings file.
+let g:coc_config_home = expand('~/.config/nvim')
+
+" Detect TOML for the sample files.
+autocmd BufRead,BufNewFile *.toml set filetype=toml

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Smoke tests for coc-toml inside the Docker / Podman image.
+#
+# Strategy:
+#   * The build itself is checked by running `node --check` on the bundled
+#     extension entry point — catches syntax errors and missing files.
+#   * The Tombi binary is bundled in the image so we can exercise project
+#     config discovery and TOML-version switching directly via `tombi lint`
+#     without needing a live coc.nvim session (headless coc.nvim has
+#     unreliable initialization behavior for automated tests).
+#
+# Modes:
+#   smoke-test                   build check + tombi --version (no scenarios)
+#   smoke-test all               build check + every scenario below
+#   smoke-test no-config         lint a fixture with NO tombi.toml
+#                                (sample is TOML 1.0-compatible — must PASS)
+#   smoke-test with-config-v1.0  fixture with tombi.toml pinning v1.0.0;
+#                                sample uses v1.1-only syntax — must FAIL
+#   smoke-test with-config-v1.1  fixture with tombi.toml pinning v1.1.0;
+#                                sample uses v1.1-only syntax — must PASS
+#
+# Escape hatch: any argv that doesn't match a known mode is exec'd directly,
+# e.g. `smoke-test nvim /work/examples/test.toml`.
+
+set -euo pipefail
+
+FIXTURES_ROOT=/work/docker/fixtures
+EXT_BUNDLE=/work/lib/index.js
+
+print_header() {
+  echo "[smoke-test] coc-toml version: $(node -p "require('/work/package.json').version")"
+  echo "[smoke-test] tombi: $(tombi --version)"
+  echo "[smoke-test] node:  $(node --version)"
+}
+
+check_build() {
+  echo "[smoke-test] checking build artifact: ${EXT_BUNDLE}"
+  if [[ ! -s "$EXT_BUNDLE" ]]; then
+    echo "[smoke-test] FAIL: ${EXT_BUNDLE} missing or empty"
+    return 1
+  fi
+  # Parse-only check: catches syntax errors without requiring coc.nvim runtime.
+  if ! node --check "$EXT_BUNDLE"; then
+    echo "[smoke-test] FAIL: ${EXT_BUNDLE} has JS syntax errors"
+    return 1
+  fi
+  echo "[smoke-test] PASS: build artifact parses"
+  return 0
+}
+
+# Run one fixture scenario.
+#
+# Args:
+#   $1 = scenario directory name under fixtures/
+#   $2 = expected outcome: "pass" (lint exits 0) or "fail" (lint exits non-zero)
+#   $3 = required substring in lint output (only checked when expected="fail")
+run_scenario() {
+  local name="$1"
+  local expected="$2"
+  local needle="${3:-}"
+  local dir="${FIXTURES_ROOT}/${name}"
+
+  if [[ ! -d "$dir" ]]; then
+    echo "[smoke-test] FAIL ${name}: fixture directory missing: $dir"
+    return 1
+  fi
+
+  echo "[smoke-test] --- scenario: ${name} (expect=${expected}) ---"
+  echo "[smoke-test]   dir=${dir}"
+
+  local out rc
+  set +e
+  out=$(cd "$dir" && tombi lint sample.toml 2>&1)
+  rc=$?
+  set -e
+
+  echo "$out" | sed 's/^/      /'
+  echo "[smoke-test]   lint exit=${rc}"
+
+  case "$expected" in
+    pass)
+      if [[ $rc -eq 0 ]]; then
+        echo "[smoke-test]   PASS ${name}: lint succeeded as expected"
+        return 0
+      fi
+      echo "[smoke-test]   FAIL ${name}: expected lint to succeed (exit=0), got ${rc}"
+      return 1
+      ;;
+    fail)
+      if [[ $rc -eq 0 ]]; then
+        echo "[smoke-test]   FAIL ${name}: expected lint to fail, but it succeeded"
+        return 1
+      fi
+      if [[ -n "$needle" ]] && ! grep -qF "$needle" <<<"$out"; then
+        echo "[smoke-test]   FAIL ${name}: lint failed but output missing '${needle}'"
+        return 1
+      fi
+      echo "[smoke-test]   PASS ${name}: lint failed as expected"
+      return 0
+      ;;
+    *)
+      echo "[smoke-test]   FAIL ${name}: unknown expected outcome '${expected}'"
+      return 1
+      ;;
+  esac
+}
+
+run_all_scenarios() {
+  local rc=0
+  run_scenario no-config         pass                                              || rc=$?
+  run_scenario with-config-v1.0  fail "TOML v1.0.0 or earlier"                     || rc=$?
+  run_scenario with-config-v1.1  pass                                              || rc=$?
+  return $rc
+}
+
+# --- main ---
+
+print_header
+
+case "${1:-}" in
+  "" )
+    check_build
+    ;;
+  all )
+    rc=0
+    check_build || rc=$?
+    run_all_scenarios || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      echo "[smoke-test] ALL PASS"
+    else
+      echo "[smoke-test] AT LEAST ONE CHECK FAILED (rc=$rc)"
+    fi
+    exit $rc
+    ;;
+  no-config )
+    run_scenario no-config pass
+    ;;
+  with-config-v1.0 )
+    run_scenario with-config-v1.0 fail "TOML v1.0.0 or earlier"
+    ;;
+  with-config-v1.1 )
+    run_scenario with-config-v1.1 pass
+    ;;
+  build )
+    check_build
+    ;;
+  * )
+    # Escape hatch: pass through to exec.
+    exec "$@"
+    ;;
+esac

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -44,7 +44,23 @@ check_build() {
     echo "[smoke-test] FAIL: ${EXT_BUNDLE} has JS syntax errors"
     return 1
   fi
-  echo "[smoke-test] PASS: build artifact parses"
+  # Feature markers: stable string literals from syncConfig.ts and
+  # userSchemas.ts. esbuild bundles preserve string literals, so a missing
+  # marker means the wiring was dropped from the bundle.
+  local missing=0
+  for needle in \
+      'workspace/didChangeConfiguration' \
+      'toml-version' \
+      'tombi/associateSchema'; do
+    if ! grep -qF "$needle" "$EXT_BUNDLE"; then
+      echo "[smoke-test] FAIL: bundle missing feature marker '${needle}'"
+      missing=1
+    fi
+  done
+  if [[ $missing -ne 0 ]]; then
+    return 1
+  fi
+  echo "[smoke-test] PASS: build artifact parses and includes expected features"
   return 0
 }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,20 @@
     "prettier:base": "prettier --parser typescript --single-quote",
     "prettier": "pnpm prettier:base --list-different \"src/**/*.ts\"",
     "format": "pnpm prettier:base --write \"src/**/*.ts\"",
-    "watch": "pnpm build --watch"
+    "watch": "pnpm build --watch",
+    "docker:build": "docker build -t coc-toml-test .",
+    "docker:test": "docker run --rm coc-toml-test",
+    "docker:test:all": "docker run --rm coc-toml-test all",
+    "docker:test:no-config": "docker run --rm coc-toml-test no-config",
+    "docker:test:config-v1.0": "docker run --rm coc-toml-test with-config-v1.0",
+    "docker:test:config-v1.1": "docker run --rm coc-toml-test with-config-v1.1",
+    "docker:shell": "docker run --rm -it --entrypoint bash coc-toml-test",
+    "docker:nvim": "docker run --rm -it coc-toml-test nvim /work/examples/test.toml",
+    "compose:test": "docker compose -f docker/compose.yaml run --rm test",
+    "compose:test:all": "docker compose -f docker/compose.yaml run --rm test-all",
+    "compose:shell": "docker compose -f docker/compose.yaml run --rm shell",
+    "compose:nvim": "docker compose -f docker/compose.yaml run --rm nvim",
+    "test": "pnpm docker:build && pnpm docker:test:all"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
Adds a Dockerfile, compose setup, and fixture-driven smoke tests that verify project-level tombi.toml correctly switches the TOML spec version (v1.0.0 vs v1.1.0). A new GitHub Actions workflow runs the suite on push to main.

- Dockerfile bundles node 24, neovim 0.10.4, and the tombi CLI 0.11.4 so headless runs avoid the interactive auto-download prompt.
- docker/fixtures/{no-config,with-config-v1.0,with-config-v1.1} drive the scenarios; v1.1-only syntax (multi-line inline table) is used to expose the version difference.
- docker/smoke-test.sh checks the build artifact and dispatches each scenario; tombi CLI is used directly because headless coc.nvim initialization is unreliable for automated tests.
- .github/workflows/docker-test.yml builds with buildx + GHA cache and runs only on push to main / workflow_dispatch.
- package.json gets docker:* / compose:* scripts and a top-level pnpm test that builds the image and runs all scenarios.